### PR TITLE
AUT-2688: Upgrade aws dependency to 3.x

### DIFF
--- a/alerts-src/alerts.js
+++ b/alerts-src/alerts.js
@@ -67,16 +67,16 @@ const handler = async function(event, context) { // eslint-disable-line no-unuse
 
     var config = {
         method: 'post',
-        url: slackHookUrl,
         headers: {
             'Content-Type': 'application/json'
         },
-        data : JSON.stringify(formatMessage(snsMessage, colorCode, snsMessageFooter))
+        body : JSON.stringify(formatMessage(snsMessage, colorCode, snsMessageFooter))
     };
     console.log("Sending alert to slack");
     try {
-        const response = await axios(config);
-        console.log(JSON.stringify(response.data));
+        const response = await fetch(slackHookUrl, config);
+        const message = await response.text();
+        console.log(message);
     } catch (error) {
         console.log(error);
     }

--- a/alerts-src/aws.js
+++ b/alerts-src/aws.js
@@ -1,13 +1,15 @@
-const AWS = require("aws-sdk");  // eslint-disable-line node/no-unpublished-require
+const {
+  SSM
+} = require("@aws-sdk/client-ssm");
 
-const SSM = new AWS.SSM();
+const client = new SSM();
 
 const getParameter = async (parameterName) => {
 
-  const result = await SSM.getParameter({
+  const result = await client.getParameter({
     Name: `${parameterName}`,
     WithDecryption: true,
-  }).promise();
+  });
 
   return result.Parameter.Value;
 };

--- a/alerts-src/package.json
+++ b/alerts-src/package.json
@@ -4,10 +4,10 @@
   "main": "alerts.js",
   "license": "MIT",
   "dependencies": {
-    "axios": "^0.26.1"
+    "@aws-sdk/client-ssm": "3.354.0",
+    "@aws-sdk/client-sts": "3.354.0"
   },
   "devDependencies": {
-    "aws-sdk": "^2.1099.0",
     "eslint": "^7.30.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-config-prettier": "^8.3.0",


### PR DESCRIPTION
The runtime of this lambda was recently upgraded to node 18, which requires us to use version 3.x of the aws sdk. There were also some differences introduced as to how to import.

This replicates what has already been done in the slack-src directory here.

This is similar to the following change for the slack lambda: https://github.com/govuk-one-login/monitoring-utils/commit/9b99dc881e079711817ef760acaba4b1a0e16ebf

## What?

Please include a summary of the change.

## Why?

Please include reason for the change and any other relevant context.

## Related PRs

Please include links to PRs in other repositories relevant to this PR.
Delete this section if not needed.
